### PR TITLE
fix(deps): Add explicit dependency on figgy-pudding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,9 +1594,9 @@
       "dev": true
     },
     "figgy-pudding": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.1.tgz",
-      "integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
     },
     "figures": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://npmjs.com/package/libnpmaccess",
   "dependencies": {
     "aproba": "^2.0.0",
+    "figgy-pudding": "^3.5.1",
     "get-stream": "^4.0.0",
     "npm-package-arg": "^6.1.0",
     "npm-registry-fetch": "^3.8.0"


### PR DESCRIPTION
This removes an implicit transitive dependency that itself relies on `node_modules` being flattened by package managers.

Without this explicit dependency, stricter package managers like `pnpm` fail to install a usable copy of this library.

Refs npm/npm-registry-fetch#5

For example:
```sh
npm -g i pnpm
mkdir -p /tmp/pnpm-libnpmaccess
cd /tmp/pnpm-libnpmaccess
npm init -y
pnpm i libnpmaccess
node -p 'require("libnpmaccess")'
```

The last line dumps this error to the console:
```txt
internal/modules/cjs/loader.js:584
    throw err;
    ^

Error: Cannot find module 'figgy-pudding'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/private/tmp/pnpm-libnpmaccess/node_modules/.registry.npmjs.org/libnpmaccess/3.0.1/node_modules/libnpmaccess/index.js:3:22)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
```

`node -v`: v10.15.3
`npm -v`: v6.9.0
`pnpm -v`: v3.2.0